### PR TITLE
Removed huecker source, Added redhat source

### DIFF
--- a/unlock.sh
+++ b/unlock.sh
@@ -4,9 +4,9 @@
 new_mirrors=(
   "https://dockerhub.timeweb.cloud".
   "https://mirror.gcr.io"
+  "https://quay.io"
   "https://daocloud.io"
   "https://c.163.com"
-  "https://huecker.io"
   "https://registry.docker-cn.com"
 )
 


### PR DESCRIPTION
- Huecker is not legit image repository
- Quay is fast and legit source